### PR TITLE
Add match property

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -28,6 +28,8 @@ class Result
 
     protected $mods = [];
 
+	protected $match;
+
     /**
      * @param bool $valid
      *
@@ -245,6 +247,7 @@ class Result
             'icon',
             'mods',
             'text',
+			'match'
         ];
 
         $result = [];


### PR DESCRIPTION
This PR adds the match field/property to the Result class.

From the [documentation of the Script Filter JSON Format](https://www.alfredapp.com/help/workflows/inputs/script-filter/json/):

> match : STRING (optional)
From Alfred 3.5, the match field enables you to define what Alfred matches against when the workflow is set to "Alfred Filters Results". If match is present, it fully replaces matching on the title property.

    "match": "my family photos"

> Note that the match field is always treated as case insensitive, and intelligently treated as diacritic insensitive. If the search query contains a diacritic, the match becomes diacritic sensitive.
> 
> This option pairs well with the "Alfred Filters Results" Match Mode option.